### PR TITLE
Updates for several functions

### DIFF
--- a/R/modeling.R
+++ b/R/modeling.R
@@ -64,6 +64,16 @@ run_peak_aen <- function(seurat,
 	if (class(gene_list) == "list") {
 		gene_list <- unlist(gene_list)
 	}
+  
+  # remove genes that are not in the column names of pseudocell_mat
+  # such cases can happen when gene_list is provided separately and contains
+  # genes that are not the the expression matrix
+  if (sum(gene_list %in% colnames(pseudocell_mat)) != length(gene_list)){
+    print("The following genes were removed from gene_list because they do not exist in pseudocell_mat:")
+    print(gene_list[!gene_list %in% colnames(pseudocell_mat)])
+    gene_list = gene_list[gene_list %in% colnames(pseudocell_mat)]
+  }
+  
 
 	# prepare peak gene key
 	gene_coords <- Signac:::CollapseToLongestTranscript(Annotation(seurat))

--- a/R/modeling.R
+++ b/R/modeling.R
@@ -231,12 +231,12 @@ run_tf_aen <- function(seurat,
 	}
 
 	###############
-  # allow user defined ATAC assay name
-  tmp_assay = seurat[[peak_assay]]
-  peak_tf_key <- tmp_assay@motifs@data
-  colnames(peak_tf_key) <- unlist(tmp_assay@motifs@motif.names)
+  	# allow user defined ATAC assay name
+  	tmp_assay = seurat[[peak_assay]]
+  	peak_tf_key <- tmp_assay@motifs@data
+  	colnames(peak_tf_key) <- unlist(tmp_assay@motifs@motif.names)
 
-  # peak_tf_key <- seurat@assays$peaks@motifs@data
+  	# peak_tf_key <- seurat@assays$peaks@motifs@data
 	# colnames(peak_tf_key) <- unlist(seurat@assays$peaks@motifs@motif.names)
   ###############
 

--- a/R/modeling.R
+++ b/R/modeling.R
@@ -230,8 +230,15 @@ run_tf_aen <- function(seurat,
 		modeled_genes <- gene_list
 	}
 
-	peak_tf_key <- seurat@assays$peaks@motifs@data
-	colnames(peak_tf_key) <- unlist(seurat@assays$peaks@motifs@motif.names)
+	###############
+  # allow user defined ATAC assay name
+  tmp_assay = seurat[[peak_assay]]
+  peak_tf_key <- tmp_assay@motifs@data
+  colnames(peak_tf_key) <- unlist(tmp_assay@motifs@motif.names)
+
+  # peak_tf_key <- seurat@assays$peaks@motifs@data
+	# colnames(peak_tf_key) <- unlist(seurat@assays$peaks@motifs@motif.names)
+  ###############
 
 	regulator_tf_names <- colnames(peak_tf_key)
 	regulator_tf_names <- regulator_tf_names[which(regulator_tf_names %in% colnames(pseudocell_mat))]

--- a/R/modeling.R
+++ b/R/modeling.R
@@ -188,6 +188,7 @@ run_peak_aen <- function(seurat,
 #' @param globals_maxsize If running into RAM problems during multithreading, can use this parameter to set future.globals.maxSize if not done manually
 #' @param verbose Boolean to determine whether to run silently
 #' @param bs_seed Seed for reproducibility in determining bootstrap seeds, set to NULL if not needed
+#' @param peak_assay Name of ATAC assay to use for peak information, set to "peaks" by default
 #' @param multi_seed Seed for reproducibility during multithreaded model training, set to NULL if not needed
 #'
 #' @return list of lists per modeled gene, containing modeling and TF gene regulatory network information

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -440,7 +440,9 @@ plot_tf_rankings <- function(results_df,
 		    geom_bar(stat = "identity", color = "black", size = 0.0, width = 1, alpha = .8) + 
 		    scale_fill_manual(values = colors) +
 	    	theme_classic() + xlab("TF") + ylab("Predicted regulatory influence") +
-		    geom_text_repel(aes(label = label), max.overlaps = 100, size = 5) + 
+		    # geom_text_repel(aes(label = label), max.overlaps = 100, size = 5) + 
+	      geom_text_repel(aes(label = label), max.overlaps = 100, size = 5, force = 10, xlim = c(-Inf, Inf)) + 
+	      coord_cartesian(clip = "off") +   ## to allow labels exceed the x axis boundary in case multiple labels are mixed up 
 		    theme(text = element_text(size = 14), axis.text = element_text(size = 14))
 	return(g)
 }

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -391,7 +391,9 @@ plot_graph_rankings <- function(tf_results,
 #' @param two_tailed Boolean whether P value cutoff is for a two-tailed test
 #' @param top_n_to_label Number of top positive and negative TFs to label on plot if tfs_to_label is NULL
 #' @param label_tfs Boolean whether to label TFs on plot
-#' @param colors Colors for negative and positive regulatory scores
+#' @param colors A vector of two color values: color1 for negative and color2 for positive scores
+#' @param ident1 Label for negative scores, default FR
+#' @param ident2 Label for positive scores, default H
 #'
 #' @return ggplot of motif enrichment, fold enrichment vs -log(p-value)
 #' @export
@@ -403,7 +405,8 @@ plot_tf_rankings <- function(results_df,
 							 two_tailed = TRUE,
 							 top_n_to_label = 5,
 							 label_tfs = TRUE,
-							 colors = c("#5862AD", "#39B54A")) {
+							 colors = c("#5862AD", "#39B54A"), 
+							 ident1 = "FR", ident2 = "H") {
 	require(ggplot2)
 	require(ggrepel)
 
@@ -423,7 +426,11 @@ plot_tf_rankings <- function(results_df,
 		results_df$label[which(results_df$TF_name %in% tfs_to_label)] <- results_df$TF_name[which(results_df$TF_name %in% tfs_to_label)]
 	}
 
-	results_df$comp <- ifelse(results_df$Score > 0, "H", "FR")
+	# allow change the legend label for ident1 and ident2. 
+	results_df$comp <- ifelse(results_df$Score > 0, ident2, ident1)
+	# fix the order of color with color 1 corresponding to ident 1, and color 2 corresponding to ident 2.
+	results_df$comp = factor(results_df$comp, levels = c(ident1, ident2))
+	
 	if (length(which(results_df$Score < 0)) == 0) {
 		colors <- colors[1]
 	}

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -391,9 +391,9 @@ plot_graph_rankings <- function(tf_results,
 #' @param two_tailed Boolean whether P value cutoff is for a two-tailed test
 #' @param top_n_to_label Number of top positive and negative TFs to label on plot if tfs_to_label is NULL
 #' @param label_tfs Boolean whether to label TFs on plot
-#' @param colors A vector of two color values: color1 for negative and color2 for positive scores
-#' @param ident1 Label for negative scores, default FR
-#' @param ident2 Label for positive scores, default H
+#' @param colors A vector of two color values: color1 for positive and color2 for negative scores
+#' @param ident1 Label for positive scores, default FR
+#' @param ident2 Label for negative scores, default H
 #'
 #' @return ggplot of motif enrichment, fold enrichment vs -log(p-value)
 #' @export
@@ -405,8 +405,8 @@ plot_tf_rankings <- function(results_df,
 							 two_tailed = TRUE,
 							 top_n_to_label = 5,
 							 label_tfs = TRUE,
-							 colors = c("#5862AD", "#39B54A"), 
-							 ident1 = "FR", ident2 = "H") {
+							 colors = c("#39B54A", "#5862AD"), 
+							 ident1 = "H", ident2 = "FR") {
 	require(ggplot2)
 	require(ggrepel)
 
@@ -427,8 +427,8 @@ plot_tf_rankings <- function(results_df,
 	}
 
 	# allow change the legend label for ident1 and ident2. 
-	results_df$comp <- ifelse(results_df$Score > 0, ident2, ident1)
-	# fix the order of color with color 1 corresponding to ident 1, and color 2 corresponding to ident 2.
+	results_df$comp <- ifelse(results_df$Score > 0, ident1, ident2)
+	# freeze the order of color with color 1 corresponds to ident 1, and color 2 corresponds to ident 2.
 	results_df$comp = factor(results_df$comp, levels = c(ident1, ident2))
 	
 	if (length(which(results_df$Score < 0)) == 0) {

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -391,9 +391,9 @@ plot_graph_rankings <- function(tf_results,
 #' @param two_tailed Boolean whether P value cutoff is for a two-tailed test
 #' @param top_n_to_label Number of top positive and negative TFs to label on plot if tfs_to_label is NULL
 #' @param label_tfs Boolean whether to label TFs on plot
-#' @param colors A vector of two color values: color1 for positive and color2 for negative scores
-#' @param ident1 Label for positive scores, default FR
-#' @param ident2 Label for negative scores, default H
+#' @param colors A vector of two color values: color1 for ident1 / positive and color2 for ident2 / negative scores
+#' @param ident1 Label for positive scores, default H (Healthy)
+#' @param ident2 Label for negative scores, default FR (Faired-Repaired)
 #'
 #' @return ggplot of motif enrichment, fold enrichment vs -log(p-value)
 #' @export

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -441,7 +441,7 @@ plot_tf_rankings <- function(results_df,
 		    scale_fill_manual(values = colors) +
 	    	theme_classic() + xlab("TF") + ylab("Predicted regulatory influence") +
 		    # geom_text_repel(aes(label = label), max.overlaps = 100, size = 5) + 
-	      geom_text_repel(aes(label = label), max.overlaps = 100, size = 5, force = 10, xlim = c(-Inf, Inf)) + 
+	      geom_text_repel(aes(label = label), max.overlaps = 100, size = 5, xlim = c(-Inf, Inf)) + 
 	      coord_cartesian(clip = "off") +   ## to allow labels exceed the x axis boundary in case multiple labels are mixed up 
 		    theme(text = element_text(size = 14), axis.text = element_text(size = 14))
 	return(g)

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -179,6 +179,11 @@ apply_multi_micro_clustering <- function(seurat,
 	if (find_neighbors || is.null(seurat@neighbors$weighted.nn)) {
 		seurat <- FindMultiModalNeighbors(seurat, reduction.list = list(reduction1, reduction2),
 										  k.nn = k.nn, dims.list = dim_list)
+
+		###############
+	    # assume WNN.UMAP need to be generated
+	    seurat <- RunUMAP(seurat, nn.name = "weighted.nn", reduction.name = "WNN.UMAP", reduction.key = "wnnUMAP_")
+	    ###############
 	}
 	seurat.cds <- as.cell_data_set(seurat, assay = "SCT")
 	res <- reducedDim(seurat.cds, type = "WNN.UMAP", withDimnames = TRUE)


### PR DESCRIPTION
[apply_multi_micro_clustering]: runUMAP is subsequentially called if FindMultiModalNeighbors has been called to generate WNN. 

[run_peak_aen]: In some cases, users might provide their own gene_list which may contain genes that do not exist in pseudocell_mat. This filtering step can remove such genes that can generate errors in the 'gcdnet' training step.

[plot_tf_rankings]: allow users to define names and colors of ident1 and ident2. set 'xlim = c(-Inf, Inf)' in geom_text_repel, in case a large number of TFs is to be printed on the rank plot.